### PR TITLE
Multiple updates for AdobeDNGConverter.munki

### DIFF
--- a/AdobeDNGConverter/AdobeDNGConverter.munki.recipe
+++ b/AdobeDNGConverter/AdobeDNGConverter.munki.recipe
@@ -36,24 +36,69 @@
 	<string>com.github.sheagcraig.pkg.AdobeDNGConverter</string>
 	<key>Process</key>
 	<array>
-		<dict>
-			<key>Processor</key>
-			<string>DmgCreator</string>
-			<key>Arguments</key>
-			<dict>
-				<key>dmg_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.dmg</string>
-				<key>dmg_root</key>
-				<string>%pkg_path%</string>
-			</dict>
-		</dict>
+        <dict>
+            <key>Processor</key>
+            <string>PkgRootCreator</string>
+            <key>Arguments</key>
+            <dict>
+                <key>pkgroot</key>
+                <string>%RECIPE_CACHE_DIR%/fauxroot</string>
+                <key>pkgdirs</key>
+                <dict>
+                    <key>Applications</key>
+                    <string>0755</string>
+                </dict>
+            </dict>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>source</key>
+                <string>%RECIPE_CACHE_DIR%/unpacked/Adobe DNG Converter.app</string>
+                <key>target</key>
+                <string>%RECIPE_CACHE_DIR%/fauxroot/Applications/Adobe DNG Converter.app</string>
+                <key>overwrite</key>
+                <string>true</string>
+            </dict>
+            <key>Processor</key>
+            <string>FileMover</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>faux_root</key>
+                <string>%RECIPE_CACHE_DIR%/fauxroot</string>
+                <key>installs_item_paths</key>
+                <array>
+                    <string>/Applications/Adobe DNG Converter.app</string>
+                </array>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiInstallsItemsCreator</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>additional_pkginfo</key>
+                <dict>
+                    <key>version</key>
+                    <string>%version%</string>
+                </dict>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
 		<dict>
 			<key>Processor</key>
 			<string>MunkiImporter</string>
 			<key>Arguments</key>
 			<dict>
 				<key>pkg_path</key>
-				<string>%dmg_path%</string>
+				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.pkg</string>
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
 			</dict>


### PR DESCRIPTION
As described in the commit message, this is one PR with a few proposed improvements for this recipe. I'm still not happy with the version used for both the Munki pkginfo `version` and the key used in `/Applications/Adobe DNG Converter.app`, but currently Adobe provides no such "x.y.z" version anywhere in the bundle that I can find.

I could see a future change added to Shea's pkg recipe that would at least parse out a version without any alpha characters by parsing (or regex matching) the unpacked pkg `Distribution` file, which contains this. This PR would at least be a step in a direction towards a pkginfo I don't have to edit as much manually with each release.