### PR TITLE
Remove NAME variable from app paths

### DIFF
--- a/ICanAnimate2/ICanAnimate2.munki.recipe
+++ b/ICanAnimate2/ICanAnimate2.munki.recipe
@@ -57,7 +57,7 @@
 				<key>dmg_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
 				<key>dmg_root</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/I Can Animate 2.app</string>
 			</dict>
 		</dict>
 		<dict>

--- a/MirrorDisplays/MirrorDisplays.munki.recipe
+++ b/MirrorDisplays/MirrorDisplays.munki.recipe
@@ -57,7 +57,7 @@
 				<key>dmg_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
 				<key>dmg_root</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/MirrorDisplays.app</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
Because variables can be overridden, it's a good idea to make sure that the recipe will still work even if a non-default variables used. One issue that would prevent recipes from running is using a `NAME` variable in paths that should be hard-coded (e.g. `/Applications/Foo.app`).

This PR removes the `NAME` variable from all file paths and replaces it with the actual app name, which should make the recipe more resilient for overrides.