### PR TITLE
Move EndOfCheckPhase after URLDownloader

### DIFF
--- a/ICanAnimate2/ICanAnimate2.download.recipe
+++ b/ICanAnimate2/ICanAnimate2.download.recipe
@@ -26,11 +26,11 @@
         </dict>
         <dict>
             <key>Processor</key>
-            <string>EndOfCheckPhase</string>
+            <string>URLDownloader</string>
         </dict>
         <dict>
             <key>Processor</key>
-            <string>URLDownloader</string>
+            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>


### PR DESCRIPTION
Conventionally, EndOfCheckPhase goes after the download but before subsequent processing like code signature verification or versioning.